### PR TITLE
fix: workaround to match hash in docs

### DIFF
--- a/components/Docs/Sidebar.js
+++ b/components/Docs/Sidebar.js
@@ -12,7 +12,7 @@ const Sidebar = () => (
             <div className="posts">
               {content.docs.map((docText, key) => {
                 const { title, hash } = docText;
-                return <SidebarSection key={key} text={title} link={hash} />
+                return <SidebarSection key={key} text={title} hash={hash} />
               })}
             </div>
           </Fragment>

--- a/components/Docs/SidebarSection.js
+++ b/components/Docs/SidebarSection.js
@@ -1,26 +1,41 @@
-import React, { useContext } from 'react';
+import React, { useContext, useEffect, useState } from 'react';
 
 import { DocsContext } from '../../contexts/docContext';
 
-const SidebarSection = ({text, link}) => {
+const SidebarSection = ({text, hash}) => {
   const { allContent } = useContext(DocsContext);
+  const [link, setLink] = useState(hash);
 
-  const handleOnClick = (link) => {
-    const regexp = new RegExp(/\#(.*)/gm)
-    const contentId = link.match(regexp);
+  useEffect(() => {
+    if(window) {
+      let url = window.location.href;
+      const lastNonCharacter = new RegExp(/(\/)$/gm);
+      setLink(`${url}${hash}`);
+
+      // Workarround to handle hash match
+      if(url.match(lastNonCharacter)) {
+        url.replace(lastNonCharacter, '');
+        setLink(`${url}${hash}`);
+      }
+    }
+  }, []);
+
+  const handleOnClick = () => {
+    const regexp = new RegExp(/\#(.*)/gm);
+    const contentId = hash.match(regexp);
     allContent(contentId);
   };
 
   return (
     <div className="link">
       <div className="nav-link">
-        <a onClick={() => handleOnClick(link)} href={link}>{text}</a>
+        <a onClick={() => handleOnClick()} href={link}>{text}</a>
       </div>
       <style jsx>
       {`
         {/* STYLES FOR MOBILE */}
         @media only screen and (max-width: 750px) {
-        }
+        } 
 
         {/* STYLES FOR DESKTOP */}
         @media only screen and (min-width: 751px) {

--- a/contents/documentation/sidebar.js
+++ b/contents/documentation/sidebar.js
@@ -4,43 +4,43 @@ module.exports = [
     docs: [
       {
         title: "Agenda de turnos",
-        hash: "documentation#agenda"
+        hash: "#agenda"
       },
       {
         title: "Agenda de contactos",
-        hash: "documentation#agenda-contactos"
+        hash: "#agenda-contactos"
       },
       {
         title: "Agenda de tareas",
-        hash: "documentation#agenda-tareas"
+        hash: "#agenda-tareas"
       },
       {
         title: "Pacientes",
-        hash: "documentation#pacientes"
+        hash: "#pacientes"
       },
       {
         title: "Profesionales",
-        hash: "documentation#profesionales"
+        hash: "#profesionales"
       },
       {
         title: "Obras Sociales / Prepagas",
-        hash: "documentation#obras-sociales"
+        hash: "#obras-sociales"
       },
       {
         title: "Laboratorios",
-        hash: "documentation#laboratorios"
+        hash: "#laboratorios"
       },
       {
         title: "Stock / Economato",
-        hash: "documentation#stock"
+        hash: "#stock"
       },
       {
         title: "Informes",
-        hash: "documentation#informes"
+        hash: "#informes"
       },
       {
         title: "Sistema / Usuarios",
-        hash: "documentation#sistema"
+        hash: "#sistema"
       },
   ]}
 ];


### PR DESCRIPTION
Because we don't use SSR, to match the # in client side, we have to use a workaround